### PR TITLE
Fix default dialer toast issue

### DIFF
--- a/app/src/main/java/com/easyranktools/callhistoryforanynumber/ModeSelectionActivity.java
+++ b/app/src/main/java/com/easyranktools/callhistoryforanynumber/ModeSelectionActivity.java
@@ -204,8 +204,7 @@ public class ModeSelectionActivity extends AppCompatActivity {
                 // so user can change back in settings and be prompted again on next launch
             } else {
                 Toast.makeText(this, "❌ User denied default dialer request", Toast.LENGTH_SHORT).show();
-                // Optionally stop asking again for this session
-                // DefaultDialerHelper.markDoNotAskAgain(this);
+                DefaultDialerHelper.openDefaultDialerSettings(this);
             }
             // Proceed with normal flow after the system role dialog resolves
             maybeStartModeCheck();


### PR DESCRIPTION
Implement a fallback to system settings and harden the default dialer request flow to resolve issues with the default dialer prompt not appearing.

---
<a href="https://cursor.com/background-agent?bcId=bc-08ea8411-7a64-4491-81d5-7d35f4add879">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08ea8411-7a64-4491-81d5-7d35f4add879">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

