### PR TITLE
Fix default dialer denial toast

### DIFF
--- a/app/src/main/java/com/easyranktools/callhistoryforanynumber/DefaultDialerHelper.java
+++ b/app/src/main/java/com/easyranktools/callhistoryforanynumber/DefaultDialerHelper.java
@@ -67,8 +67,10 @@ public final class DefaultDialerHelper {
             }
         }
 
+        // If we couldn't start any system prompt, just return quietly.
+        // The caller can decide next steps without forcing settings open.
         if (!started) {
-            openDefaultDialerSettings(activity);
+            return;
         }
     }
 

--- a/app/src/main/java/com/easyranktools/callhistoryforanynumber/ModeSelectionActivity.java
+++ b/app/src/main/java/com/easyranktools/callhistoryforanynumber/ModeSelectionActivity.java
@@ -198,14 +198,16 @@ public class ModeSelectionActivity extends AppCompatActivity {
 
         if (requestCode == REQUEST_CODE_SET_DEFAULT_DIALER) {
             isRequestingDefaultDialer = false;
-            if (resultCode == RESULT_OK) {
+
+            // Double-check actual state instead of relying on resultCode which may vary by OEM
+            boolean isNowDefault = DefaultDialerHelper.isDefaultDialer(this);
+            if (isNowDefault) {
                 Toast.makeText(this, "✅ App is now the default dialer!", Toast.LENGTH_SHORT).show();
-                // Reset the do-not-ask flag if previously set
-                // so user can change back in settings and be prompted again on next launch
             } else {
-                Toast.makeText(this, "❌ User denied default dialer request", Toast.LENGTH_SHORT).show();
-                DefaultDialerHelper.openDefaultDialerSettings(this);
+                // Quietly proceed without nagging; remember user's choice to avoid re-prompting
+                DefaultDialerHelper.markDoNotAskAgain(this);
             }
+
             // Proceed with normal flow after the system role dialog resolves
             maybeStartModeCheck();
         }


### PR DESCRIPTION
Stop showing the 'User denied default dialer' toast and forcing users to system settings, and implement a 'don't ask again' behavior to improve user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c021206-91ea-4a09-8287-59c059730c67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c021206-91ea-4a09-8287-59c059730c67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

