### PR TITLE
Reset app to default state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,22 +72,6 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
 
-            <!-- Handle dial intents -->
-            <intent-filter>
-                <action android:name="android.intent.action.DIAL"/>
-                <action android:name="android.intent.action.CALL"/>
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="tel"/>
-            </intent-filter>
-
-            <!-- Handle call button -->
-            <intent-filter>
-                <action android:name="android.intent.action.CALL_BUTTON"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-            </intent-filter>
-
 
         </activity>
 

--- a/app/src/main/java/com/easyranktools/callhistoryforanynumber/ModeSelectionActivity.java
+++ b/app/src/main/java/com/easyranktools/callhistoryforanynumber/ModeSelectionActivity.java
@@ -28,7 +28,7 @@ import com.google.firebase.database.ValueEventListener;
 
 public class ModeSelectionActivity extends AppCompatActivity {
     private static final String TAG = "ModeSelectionActivity";
-    private static final int SPLASH_DELAY = 2000; // 2 seconds
+    // Removed splash delay to avoid timing issues during startup
 
     private static final int REQUEST_CODE_SET_DEFAULT_DIALER = 123;
 
@@ -53,13 +53,13 @@ public class ModeSelectionActivity extends AppCompatActivity {
         initViews();
         handler = new Handler(Looper.getMainLooper());
 
-        // Prompt to be default dialer if needed
+        // Prompt to be default dialer if needed, but do not block the flow
         if (DefaultDialerHelper.shouldAskToBeDefault(this)) {
             isRequestingDefaultDialer = true;
             DefaultDialerHelper.requestToBeDefaultDialer(this, REQUEST_CODE_SET_DEFAULT_DIALER);
-        } else {
-            maybeStartModeCheck();
         }
+        // Always continue with mode check immediately
+        maybeStartModeCheck();
     }
 
     private void initViews() {
@@ -126,17 +126,11 @@ public class ModeSelectionActivity extends AppCompatActivity {
             }
         });
 
-        // Fallback timeout
-        handler.postDelayed(() -> {
-            if (!modeChecked) {
-                Log.w(TAG, "Mode check timeout, defaulting to dialer mode");
-                launchDialerMode();
-            }
-        }, 10000);
+        // Removed fallback timeout to prevent delayed navigation conflicts
     }
 
     private void launchDialerMode() {
-        handler.postDelayed(() -> MyApplication.getInstance().routeToDialerFlow(ModeSelectionActivity.this, true), 1000);
+        MyApplication.getInstance().routeToDialerFlow(ModeSelectionActivity.this, true);
     }
 
     @Override
@@ -216,7 +210,7 @@ public class ModeSelectionActivity extends AppCompatActivity {
     private void maybeStartModeCheck() {
         if (isModeCheckStarted) return;
         isModeCheckStarted = true;
-        handler.postDelayed(this::checkAppMode, 500);
+        checkAppMode();
     }
 
 }


### PR DESCRIPTION
Remove timers and dialer intent filters from `ModeSelectionActivity` to resolve startup issues and ensure immediate routing to the main dialer.

The `ModeSelectionActivity` previously had multiple delays and also handled dialer intents, which was causing conflicts and a slow startup experience. By removing these delays and delegating dialer intent handling exclusively to `DialerHomeActivity`, the app now launches directly into the intended flow without any blocking timers or ambiguous intent routing.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb238419-30f1-4250-9f95-0fc36d0c7a19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb238419-30f1-4250-9f95-0fc36d0c7a19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

