### PR TITLE
Research and implement default app selection

### DIFF
--- a/app/src/main/java/com/easyranktools/callhistoryforanynumber/DefaultDialerHelper.java
+++ b/app/src/main/java/com/easyranktools/callhistoryforanynumber/DefaultDialerHelper.java
@@ -30,7 +30,8 @@ public final class DefaultDialerHelper {
     }
 
     public static boolean shouldAskToBeDefault(Context context) {
-        return !isDefaultDialer(context) && !getPrefs(context).getBoolean(KEY_DO_NOT_ASK_DEFAULT_DIALER, false);
+        // Always ask when not default; avoid permanently suppressing the prompt
+        return !isDefaultDialer(context);
     }
 
     public static void markDoNotAskAgain(Context context) {
@@ -67,10 +68,9 @@ public final class DefaultDialerHelper {
             }
         }
 
-        // If we couldn't start any system prompt, just return quietly.
-        // The caller can decide next steps without forcing settings open.
+        // If we couldn't start any system prompt, open settings as a fallback
         if (!started) {
-            return;
+            openDefaultDialerSettings(activity);
         }
     }
 

--- a/app/src/main/java/com/easyranktools/callhistoryforanynumber/ModeSelectionActivity.java
+++ b/app/src/main/java/com/easyranktools/callhistoryforanynumber/ModeSelectionActivity.java
@@ -198,8 +198,7 @@ public class ModeSelectionActivity extends AppCompatActivity {
             if (isNowDefault) {
                 Toast.makeText(this, "✅ App is now the default dialer!", Toast.LENGTH_SHORT).show();
             } else {
-                // Quietly proceed without nagging; remember user's choice to avoid re-prompting
-                DefaultDialerHelper.markDoNotAskAgain(this);
+                // Proceed quietly; do not permanently suppress future prompts
             }
 
             // Proceed with normal flow after the system role dialog resolves


### PR DESCRIPTION
Improve default dialer request flow to always prompt when not default and provide a fallback to system settings.

The previous implementation could permanently suppress the default dialer prompt if the user declined, and it did not offer a fallback if the system's `RoleManager` or `TelecomManager` prompt failed to launch. This PR ensures the app will always attempt to become the default dialer when it's not, and gracefully handles prompt failures by directing the user to system settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-48513c69-f67c-429a-9aff-b0a35bb3d03a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-48513c69-f67c-429a-9aff-b0a35bb3d03a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

