### PR TITLE
Investigate phone app package mismatch

### DIFF
--- a/app/src/main/java/com/easyranktools/callhistoryforanynumber/DefaultDialerHelper.java
+++ b/app/src/main/java/com/easyranktools/callhistoryforanynumber/DefaultDialerHelper.java
@@ -59,7 +59,6 @@ public final class DefaultDialerHelper {
             if (telecomManager != null) {
                 if (!activity.getPackageName().equals(telecomManager.getDefaultDialerPackage())) {
                     Intent intent = new Intent(TelecomManager.ACTION_CHANGE_DEFAULT_DIALER);
-                    intent.putExtra(TelecomManager.EXTRA_CHANGE_DEFAULT_DIALER_PACKAGE_NAME, activity.getPackageName());
                     try {
                         activity.startActivityForResult(intent, requestCode);
                         started = true;

--- a/app/src/main/java/com/easyranktools/callhistoryforanynumber/ModeSelectionActivity.java
+++ b/app/src/main/java/com/easyranktools/callhistoryforanynumber/ModeSelectionActivity.java
@@ -71,25 +71,7 @@ public class ModeSelectionActivity extends AppCompatActivity {
 
 
 
-    /**
-     * Request to become the default dialer if not already
-     */
-    private void ensureDefaultDialer() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            TelecomManager telecomManager =
-                    (TelecomManager) getSystemService(Context.TELECOM_SERVICE);
-
-            if (telecomManager != null &&
-                    !getPackageName().equals(telecomManager.getDefaultDialerPackage())) {
-
-                Intent intent = new Intent(TelecomManager.ACTION_CHANGE_DEFAULT_DIALER);
-                intent.putExtra(TelecomManager.EXTRA_CHANGE_DEFAULT_DIALER_PACKAGE_NAME, getPackageName());
-                startActivity(intent);
-            } else {
-                Log.d(TAG, "Already default dialer");
-            }
-        }
-    }
+    // Removed ensureDefaultDialer(); use DefaultDialerHelper instead
 
 
     /**


### PR DESCRIPTION
Remove explicit package extra from default dialer intent and redundant method to resolve "Provided package name does not correspond to an installed Phone application." warning.

The previous approach of explicitly providing the package name in `EXTRA_CHANGE_DEFAULT_DIALER_PACKAGE_NAME` could lead to a warning if the system didn't immediately recognize the app as an eligible dialer. By removing this extra, the system will now present a chooser of all eligible dialer applications, allowing the user to select the app without encountering the warning. The `ensureDefaultDialer()` method was also removed as its functionality is now handled by `DefaultDialerHelper`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e12a233d-42c1-4d1a-b71c-f50d89f9a1f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e12a233d-42c1-4d1a-b71c-f50d89f9a1f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

